### PR TITLE
대량 데이터 jpa, jdbcTemplate 저장 테스트 코드 추가

### DIFF
--- a/src/test/kotlin/com/example/demo/core/member/SaveMassMemberDataTest.kt
+++ b/src/test/kotlin/com/example/demo/core/member/SaveMassMemberDataTest.kt
@@ -1,0 +1,45 @@
+package com.example.demo.core.member
+
+import com.example.demo.core.member.domain.Member
+import com.example.demo.createMember
+import com.example.demo.infrastructure.persistence.member.MemberJdbcRepository
+import com.example.demo.infrastructure.persistence.member.MemberJpaRepository
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.jdbc.core.JdbcTemplate
+
+@DataJpaTest
+@DisplayName("SaveMassMemberDataTest")
+class SaveMassMemberDataTest(
+    private val jdbcTemplate: JdbcTemplate,
+    private val memberJpaRepository: MemberJpaRepository,
+    private val memberJdbcRepository: MemberJdbcRepository = MemberJdbcRepository(jdbcTemplate = jdbcTemplate),
+) : FunSpec({
+
+    val count = 1_000
+
+    test("1000명의 회원 데이터를 Jpa Save()로 저장했을 때") {
+        for (i in 1..count) {
+            memberJpaRepository.save(createMember())
+        }
+    }
+
+    test("1000명의 회원 데이터를 Jpa SaveAll()로 저장했을 때") {
+        val members: MutableList<Member> = mutableListOf()
+        for (i in 1..count) {
+            members.add(createMember())
+        }
+
+        memberJpaRepository.saveAll(members)
+    }
+
+    test("1000명의 회원 데이터를 JdbcTemplate으로 저장했을 때") {
+        val members: MutableList<Member> = mutableListOf()
+        for (i in 1..count) {
+            members.add(createMember())
+        }
+
+        memberJdbcRepository.saveAll(members)
+    }
+})

--- a/src/test/kotlin/com/example/demo/core/member/query/FindMemberCountServiceTest.kt
+++ b/src/test/kotlin/com/example/demo/core/member/query/FindMemberCountServiceTest.kt
@@ -20,7 +20,8 @@ class FindMemberCountServiceTest(
         memberRepository = memberRepository,
     ),
 ) : DescribeSpec({
-    afterSpec { memberJpaRepository.deleteAll() }
+
+    beforeSpec { memberJpaRepository.deleteAll() }
 
     describe("getMemberCountByChunk 메소드는") {
         context("1000명의 회원이 존재했을 때") {

--- a/src/test/kotlin/com/example/demo/core/member/query/FindMemberCountServiceTest.kt
+++ b/src/test/kotlin/com/example/demo/core/member/query/FindMemberCountServiceTest.kt
@@ -14,51 +14,23 @@ import org.springframework.jdbc.core.JdbcTemplate
 @DataJpaTest
 @DisplayName("FindMemberCountService")
 class FindMemberCountServiceTest(
-    private val jdbcTemplate: JdbcTemplate,
     private val memberRepository: MemberRepository,
     private val memberJpaRepository: MemberJpaRepository,
-    private val memberJdbcRepository: MemberJdbcRepository = MemberJdbcRepository(jdbcTemplate = jdbcTemplate),
     private val memberCountService: FindMemberCountService = FindMemberCountService(
         memberRepository = memberRepository,
     ),
 ) : DescribeSpec({
+    afterSpec { memberJpaRepository.deleteAll() }
 
     describe("getMemberCountByChunk 메소드는") {
-        val count = 1_000
-        val members: MutableList<Member> = mutableListOf()
-        for (i in 1..count) {
-            members.add(createMember())
-        }
-
-        afterTest { memberJpaRepository.deleteAll() }
-
-        context("1000명의 회원을 Jpa SaveAll()로 저장했을 때") {
+        context("1000명의 회원이 존재했을 때") {
+            val count = 1_000
+            val members: MutableList<Member> = mutableListOf()
+            for (i in 1..count) {
+                members.add(createMember())
+            }
 
             memberJpaRepository.saveAll(members)
-
-            it("전체회원 수 1000을 리턴한다.") {
-                val result = memberCountService.getMemberCountByChunk(10)
-
-                result shouldBe count
-            }
-        }
-
-        context("1000명의 회원을 Jpa Save()로 저장했을 때") {
-
-            for (i in 1..count) {
-                memberJpaRepository.save(createMember())
-            }
-
-            it("전체회원 수 1000을 리턴한다.") {
-                val result = memberCountService.getMemberCountByChunk(10)
-
-                result shouldBe count
-            }
-        }
-
-        context("1000명의 회원을 JdbcTemplate으로 저장했을 때") {
-
-            memberJdbcRepository.saveAll(members)
 
             it("전체회원 수 1000을 리턴한다.") {
                 val result = memberCountService.getMemberCountByChunk(10)


### PR DESCRIPTION
데이터 1000개 인서트 테스트

Jpa save() > Jpa saveAll() > jdbcTemplate bulk insert 순으로 시간이 오래 걸렸음

jdbcTemplate bulk insert가 제일 빠름
Jpa saveAll()이 두번째로 빠름
반복적으로 Jpa save()가 가장 느림

Bulk Insert는 JdbcTemplate을 활용해야 함
Jpa는 데이터 저장 후 영속화를 하기 때문에 시간도 더 걸리고, OOM이 발생할 수 있음