### PR TITLE
order <> orderProduct 양방향 관계로 변경

### DIFF
--- a/src/main/kotlin/com/example/demo/core/order/domain/Order.kt
+++ b/src/main/kotlin/com/example/demo/core/order/domain/Order.kt
@@ -3,10 +3,10 @@ package com.example.demo.core.order.domain
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.FetchType.LAZY
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
-import javax.persistence.JoinColumn
 import javax.persistence.OneToMany
 import javax.persistence.Table
 
@@ -21,7 +21,6 @@ class Order(
     @Column(name = "member_name")
     val memberName: String,
 
-    @OneToMany(cascade = [CascadeType.ALL])
-    @JoinColumn(name = "order_product_id")
+    @OneToMany(fetch = LAZY, cascade = [CascadeType.PERSIST], mappedBy = "order")
     val products: MutableList<OrderProduct> = mutableListOf(),
 )

--- a/src/main/kotlin/com/example/demo/core/order/domain/OrderProduct.kt
+++ b/src/main/kotlin/com/example/demo/core/order/domain/OrderProduct.kt
@@ -2,9 +2,12 @@ package com.example.demo.core.order.domain
 
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.FetchType.LAZY
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Entity
@@ -14,6 +17,10 @@ class OrderProduct(
     @Column(name = "order_product_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "order_id")
+    var order: Order? = null,
 
     @Column(name = "order_product_name")
     val name: String,


### PR DESCRIPTION
OneToMany 단방향 관계만 존재할 경우, product insert 쿼리 실행 후 update 쿼리가 추가로 발생함
product에도 ManyToOne을 추가해서 양방향 관계로 설정

추가 고민사항
OrderProduct 입장에서는 Order가 반드시 필요한데, 테스트 데이터 생성 등 때문에 var로 선언하고, null을 허용하도록 했음
나중에 val로 변경하고, null을 제거할 수 있는 방법을 찾아야 함