### PR TITLE
order <> orderProduct 양방향 관계 설정 v2

### DIFF
--- a/src/main/kotlin/com/example/demo/core/order/domain/Order.kt
+++ b/src/main/kotlin/com/example/demo/core/order/domain/Order.kt
@@ -3,6 +3,7 @@ package com.example.demo.core.order.domain
 import javax.persistence.CascadeType
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -13,15 +14,21 @@ import javax.persistence.Table
 @Entity
 @Table(name = "orders")
 class Order(
+    @Column(name = "member_name")
+    val memberName: String,
+) {
     @Id
     @Column(name = "order_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long? = null
 
-    @Column(name = "member_name")
-    val memberName: String,
+    @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], mappedBy = "order")
+    private val _products: MutableList<OrderProduct> = mutableListOf()
 
-    @OneToMany(cascade = [CascadeType.ALL])
-    @JoinColumn(name = "order_product_id")
-    val products: MutableList<OrderProduct> = mutableListOf(),
-)
+    val products: List<OrderProduct>
+        get() = _products.toList()
+
+    fun addProduct(product: OrderProduct) {
+        _products.add(product)
+    }
+}

--- a/src/main/kotlin/com/example/demo/core/order/domain/OrderProduct.kt
+++ b/src/main/kotlin/com/example/demo/core/order/domain/OrderProduct.kt
@@ -2,22 +2,29 @@ package com.example.demo.core.order.domain
 
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import javax.persistence.Table
 
 @Entity
 @Table(name = "order_product")
 class OrderProduct(
-    @Id
-    @Column(name = "order_product_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
-
     @Column(name = "order_product_name")
     val name: String,
 
     @Column(name = "order_product_quantity")
     val quantity: Long,
-)
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "order_id")
+    val order: Order
+) {
+    @Id
+    @Column(name = "order_product_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/com/example/demo/core/order/domain/OrderProduct.kt
+++ b/src/main/kotlin/com/example/demo/core/order/domain/OrderProduct.kt
@@ -21,7 +21,7 @@ class OrderProduct(
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "order_id")
-    val order: Order
+    val order: Order,
 ) {
     @Id
     @Column(name = "order_product_id")

--- a/src/testFixtures/kotlin/com/example/demo/OrderFixtures.kt
+++ b/src/testFixtures/kotlin/com/example/demo/OrderFixtures.kt
@@ -3,22 +3,22 @@ package com.example.demo
 import com.example.demo.core.order.domain.Order
 import com.example.demo.core.order.domain.OrderProduct
 
-fun createOrder(
-    memberName: String = "어피치",
-    products: MutableList<OrderProduct> = mutableListOf(createOrderProduct()),
-): Order {
-    return Order(
-        memberName = memberName,
-        products = products,
-    )
+fun createOrder(memberName: String = "어피치"): Order {
+    val order = Order(memberName = memberName)
+    listOf(createOrderProduct(order = order))
+        .forEach { order.addProduct(it) }
+
+    return order
 }
 
 fun createOrderProduct(
     name: String = "카스타드",
     quantity: Long = 1,
+    order: Order,
 ): OrderProduct {
     return OrderProduct(
         name = name,
         quantity = quantity,
+        order = order,
     )
 }


### PR DESCRIPTION
https://github.com/junho3/practice-kotlin-spring-boot/pull/8 v1에서 수정한 사항

products를 기본 생성자에서 제외하고, 백킹프로필드 적용

양방향 관계로 인해 닭(order의 products 셋팅)이 먼저냐 달걀(product의 order 셋팅)이 먼저냐 개념 충돌
지금 방식은 order를 먼저 생성하고, product를 생성할 때 order를 넘겨주고, order.products에 product를 채워주는 방식