### PR TITLE
allopen, noarg 디펜던시 및 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
     kotlin("jvm") version "1.6.21"
     kotlin("plugin.spring") version "1.6.21"
     kotlin("plugin.jpa") version "1.6.21"
+    kotlin("plugin.allopen") version "1.6.21"
+    kotlin("plugin.noarg") version "1.6.21"
 }
 
 group = "com.example"
@@ -38,6 +40,18 @@ dependencies {
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     testImplementation("com.h2database:h2")
     testImplementation("io.mockk:mockk:1.13.2")
+
+    allOpen {
+        annotation("javax.persistence.Entity")
+        annotation("javax.persistence.MappedSuperclass")
+        annotation("javax.persistence.Embeddable")
+    }
+
+    noArg {
+        annotation("javax.persistence.Entity")
+        annotation("javax.persistence.MappedSuperclass")
+        annotation("javax.persistence.Embeddable")
+    }
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
코틀린 클래스는 기본적으로  final이므로 ManyToOne 관계에서 lazy loading 옵션을 적용하여도, lazy loading 대상 객체가 Proxy가 아니라서 Select 쿼리가 추가로 발생함
allopen, noarg 디펜던시를 추가해야 lazy loading 대상 객체가 Proxy 객체로 생성되기 때문에 Select 쿼리가 발생하지 않음

개인적으로 일반적인 조회는 OneToMany 관계의 어그리게이트 루트를 통해서 해야한다고 생각하고,
ManyToOne처럼 하위 엔티티에서 상위 엔티티를 조회하는 것은 맞지 않다고 생각

https://alkhwa-113.tistory.com/entry/%EC%BD%94%ED%8B%80%EB%A6%B0%EA%B3%BC-Hibernate-CGLIB-Proxy-%EC%98%A4%ED%95%B4%EC%99%80-%EC%9E%AC%EB%8C%80%EB%A1%9C%EB%90%9C-%EC%82%AC%EC%9A%A9%EB%B2%95-2

https://hyeon9mak.github.io/kotlin-jpa-essentials/