### PR TITLE
Transactional 람다 메소드를 정적으로 사용할 수 있도록 변경

### DIFF
--- a/src/main/kotlin/com/example/demo/config/persistence/Transactional.kt
+++ b/src/main/kotlin/com/example/demo/config/persistence/Transactional.kt
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
-class Transaction {
+class Transactional {
     @Transactional
     operator fun <T> invoke(functionInTransaction: () -> T?): T? {
         return functionInTransaction()

--- a/src/main/kotlin/com/example/demo/config/persistence/Transactional.kt
+++ b/src/main/kotlin/com/example/demo/config/persistence/Transactional.kt
@@ -5,9 +5,8 @@ import org.springframework.transaction.annotation.Transactional
 
 @Component
 class Transactional(
-    _transactionalAdvice: TransactionalAdvice
+    _transactionalAdvice: TransactionalAdvice,
 ) {
-
     init {
         transactional = _transactionalAdvice
     }

--- a/src/main/kotlin/com/example/demo/config/persistence/Transactional.kt
+++ b/src/main/kotlin/com/example/demo/config/persistence/Transactional.kt
@@ -4,9 +4,27 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
 @Component
-class Transactional {
-    @Transactional
-    operator fun <T> invoke(functionInTransaction: () -> T?): T? {
-        return functionInTransaction()
+class Transactional(
+    _transactionalAdvice: TransactionalAdvice
+) {
+
+    init {
+        transactional = _transactionalAdvice
+    }
+
+    companion object {
+        private lateinit var transactional: TransactionalAdvice
+
+        operator fun <T> invoke(function: () -> T): T {
+            return transactional { function() }
+        }
+    }
+
+    @Component
+    class TransactionalAdvice {
+        @Transactional
+        operator fun <T> invoke(function: () -> T): T {
+            return function()
+        }
     }
 }

--- a/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
+++ b/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
@@ -13,15 +13,15 @@ import org.hibernate.LazyInitializationException
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 
-@Import(Transaction::class)
+@Import(Transactional::class)
 @DataJpaTest
-@DisplayName("TransactionTest")
-class TransactionTest(
+@DisplayName("TransactionalTest")
+class TransactionalTest(
     private val orderRepository: OrderRepository,
     private val findOrderService: FindOrderService = FindOrderService(
         orderRepository = orderRepository,
     ),
-    private val transaction: Transaction,
+    private val transactional: Transactional,
 ) : DescribeSpec({
 
     beforeSpec {
@@ -34,7 +34,7 @@ class TransactionTest(
 
         context("invoke 메소드를 사용하면") {
             it("Order 객체 조회 후, Lazy 로딩하여 products 객체에 접근한다.") {
-                transaction {
+                transactional {
                     val result = findOrderService.findById(1)
 
                     result.shouldBeInstanceOf<Order>()

--- a/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
+++ b/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
@@ -11,9 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.hibernate.LazyInitializationException
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.context.annotation.Import
 
-@Import(Transactional::class)
 @DataJpaTest
 @DisplayName("TransactionalTest")
 class TransactionalTest(
@@ -21,7 +19,6 @@ class TransactionalTest(
     private val findOrderService: FindOrderService = FindOrderService(
         orderRepository = orderRepository,
     ),
-    private val transactional: Transactional,
 ) : DescribeSpec({
 
     beforeSpec {
@@ -34,7 +31,7 @@ class TransactionalTest(
 
         context("invoke 메소드를 사용하면") {
             it("Order 객체 조회 후, Lazy 로딩하여 products 객체에 접근한다.") {
-                transactional {
+                Transactional {
                     val result = findOrderService.findById(1)
 
                     result.shouldBeInstanceOf<Order>()

--- a/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
+++ b/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
@@ -10,9 +10,11 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.hibernate.LazyInitializationException
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 
-@DataJpaTest
+@ActiveProfiles("test")
+@SpringBootTest
 @DisplayName("TransactionalTest")
 class TransactionalTest(
     private val orderRepository: OrderRepository,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    activate:
+      on-profile: test
   datasource:
     reader:
       driver-class-name: org.h2.Driver


### PR DESCRIPTION
기존 Transactional은 서비스 클래스에서 Bean으로 주입받아 사용해야 하므로 사용성이 떨어지고, 도메인 로직에 불필요한 Bean을 주입 받는 문제가 있었음

Transactional 람도 메소드를 정적으로 사용할 수 있도록 변경함

https://hudi.blog/jpa-lazy-loading-issue-during-e2e-testing/
https://tech.kakaopay.com/post/overcome-spring-aop-with-kotlin/