### PR TITLE
양수, 음수, .5에 따른 올림, 내림, 반올림 테스트

### DIFF
--- a/src/test/kotlin/com/example/demo/CeilTest.kt
+++ b/src/test/kotlin/com/example/demo/CeilTest.kt
@@ -1,0 +1,22 @@
+package com.example.demo
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.math.ceil
+
+@DisplayName("양수, 음수에 따른 올림 테스트")
+internal class CeilTest : FunSpec({
+
+    test("4.5를 ceil하면 5가 된다") {
+        val actual = ceil(4.5)
+
+        actual shouldBe 5
+    }
+
+    test("-4.5를 ceil하면 -4가 된다") {
+        val actual = ceil(-4.5)
+
+        actual shouldBe -4
+    }
+})

--- a/src/test/kotlin/com/example/demo/FloorTest.kt
+++ b/src/test/kotlin/com/example/demo/FloorTest.kt
@@ -1,0 +1,22 @@
+package com.example.demo
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.math.floor
+
+@DisplayName("양수, 음수에 따른 반올림 테스트")
+internal class FloorTest : FunSpec({
+
+    test("4.5를 floor하면 4가 된다") {
+        val actual = floor(4.5)
+
+        actual shouldBe 4
+    }
+
+    test("-4.5를 floor하면 -5가 된다") {
+        val actual = floor(-4.5)
+
+        actual shouldBe -5
+    }
+})

--- a/src/test/kotlin/com/example/demo/FloorTest.kt
+++ b/src/test/kotlin/com/example/demo/FloorTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlin.math.floor
 
-@DisplayName("양수, 음수에 따른 반올림 테스트")
+@DisplayName("양수, 음수에 따른 내림 테스트")
 internal class FloorTest : FunSpec({
 
     test("4.5를 floor하면 4가 된다") {

--- a/src/test/kotlin/com/example/demo/RoundTest.kt
+++ b/src/test/kotlin/com/example/demo/RoundTest.kt
@@ -1,0 +1,35 @@
+package com.example.demo
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.math.round
+import kotlin.math.roundToLong
+
+@DisplayName("코틀린 반올림 함수별 반올림 테스트")
+class RoundTest : FunSpec({
+
+    test("4.5를 round하면 4가 된다.") {
+        val actual = round(4.5)
+
+        actual shouldBe 4
+    }
+
+    test("-4.5를 round하면 -4가 된다.") {
+        val actual = round(-4.5)
+
+        actual shouldBe -4
+    }
+
+    test("4.5를 roundToLong하면 5가 된다.") {
+        val actual = 4.5.roundToLong()
+
+        actual shouldBe 5
+    }
+
+    test("-4.5를 roundToLong하면 -5가 된다.") {
+        val actual = -4.5.roundToLong()
+
+        actual shouldBe -5
+    }
+})


### PR DESCRIPTION
1. 양수와 음수에 따라 올림, 내림, 반올림이 예상과 다르게 동작하는 것을 확인
2. 코틀린에서 `.5`를 반올림 할 때 메소드별로 처리 방식이 다른 것 확인

----

양수일 때 올림, 내림은 예상대로 동작함
4.6을 올림하면 5
4.6을 내림하면 4

코틀린 floor 메소드는 Java의 Math.floor를 사용하며, 실제 구현체는 floorOrCeil() 메소드가 있음
floorOrCeil() 메소드에서 양수와 음수에 따라 처리 차이가 있음

---- 

음수일 때 올림, 내림은 예상대로 동작하지 않음
-4.6을 올림하면 -4
-4.6을 내림하면 -5

----

`.5`를 코틀린의 round 메소드를 사용하여 반올림하면 예상대로 동작하지 않음
4.5를 round 반올림하면 4
-4.5를 round 반올림하면 -4

round 메소드는 내부적으로 Math.rint를 사용하며, 오사오입

----

`.5`를 코틀린의 roundToLong 메소드를 사용하여 반올림하면 예상대로 동작함
4.5를 roundToLong으로 반올림하면 5
-4.5를 roundToLong으로 반올림하면 -5

roundToLong 메소드는 내부적으로 Math.round를 사용하며, 사사오입

참고)
사사오입, 오사오입: https://uknowblog.tistory.com/338