### PR TITLE
feature/fix-round-test

### DIFF
--- a/src/test/kotlin/com/example/demo/RoundTest.kt
+++ b/src/test/kotlin/com/example/demo/RoundTest.kt
@@ -46,4 +46,10 @@ internal class RoundTest : FunSpec({
 
         actual shouldBe -5
     }
+
+    test("-4.5를 roundToLong.unaryMinus 하면 -5가 된다.") {
+        val actual = 4.5.roundToLong().unaryMinus()
+
+        actual shouldBe -5
+    }
 })

--- a/src/test/kotlin/com/example/demo/RoundTest.kt
+++ b/src/test/kotlin/com/example/demo/RoundTest.kt
@@ -27,8 +27,22 @@ internal class RoundTest : FunSpec({
         actual shouldBe 5
     }
 
-    test("-4.5를 roundToLong하면 -5가 된다.") {
+    test("(-4.5)를 roundToLong하면 -4가 된다.") {
         val actual = (-4.5).roundToLong()
+
+        actual shouldBe -4
+    }
+
+    test("변수로된 -4.5를 roundToLong하면 -4가 된다.") {
+        val negativeNumber = -4.5
+        val actual = negativeNumber.roundToLong()
+
+        actual shouldBe -4
+    }
+
+    test("-4.5를 roundToLong하면 -5가 된다.") {
+        // (-4.5)와 무엇이 다른가?
+        val actual = -4.5.roundToLong()
 
         actual shouldBe -5
     }


### PR DESCRIPTION
-4.5.roundToLong 과 (-4.5).roundToLong의 결과가 달라 테스트 코드가 깨짐
왜 결과가 다르게 나오는지 원인은 찾지 못 했음

값(-4.5)을 보통 변수에 담아서 사용하니깐 현업에서 문제될 요지는 없어보이나, 주의해야할 듯