### PR TITLE
Feature/add exposed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "2.7.13"
     id("io.spring.dependency-management") version "1.0.15.RELEASE"
-    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.6.1"
     id("java-test-fixtures")
 
     kotlin("jvm") version "1.6.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,12 @@ dependencies {
     /** JPA */
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
+    /** Exposed */
+    implementation("org.jetbrains.exposed:exposed-core:0.44.0")
+    implementation("org.jetbrains.exposed:exposed-dao:0.44.0")
+    implementation("org.jetbrains.exposed:exposed-jdbc:0.44.0")
+    implementation("org.jetbrains.exposed:exposed-java-time:0.44.0")
+
     runtimeOnly("com.h2database:h2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/example/demo/config/persistence/ExposedDataSourceConfig.kt
+++ b/src/main/kotlin/com/example/demo/config/persistence/ExposedDataSourceConfig.kt
@@ -1,0 +1,29 @@
+package com.example.demo.config.persistence
+
+import org.jetbrains.exposed.sql.Database
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ExposedDataSourceConfig(
+    @Value("\${spring.datasource.writer.driver-class-name}")
+    private val driverClassName: String,
+    @Value("\${spring.datasource.writer.jdbc-url}")
+    private val jdbcUrl: String,
+    @Value("\${spring.datasource.writer.username}")
+    private val userName: String,
+    @Value("\${spring.datasource.writer.password}")
+    private val password: String,
+) {
+
+    @Bean
+    fun exposedDataSource(): Database {
+        return Database.connect(
+            url = jdbcUrl,
+            driver = driverClassName,
+            user = userName,
+            password = password,
+        )
+    }
+}

--- a/src/main/kotlin/com/example/demo/core/member/domain/Members.kt
+++ b/src/main/kotlin/com/example/demo/core/member/domain/Members.kt
@@ -6,5 +6,5 @@ object Members : LongIdTable(
     name = "member",
     columnName = "member_id",
 ) {
-    val member = varchar(name = "member_name", length = 64)
+    val name = varchar(name = "member_name", length = 64)
 }

--- a/src/main/kotlin/com/example/demo/core/member/domain/Members.kt
+++ b/src/main/kotlin/com/example/demo/core/member/domain/Members.kt
@@ -1,0 +1,10 @@
+package com.example.demo.core.member.domain
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+
+object Members : LongIdTable(
+    name = "member",
+    columnName = "member_id",
+) {
+    val member = varchar(name = "member_name", length = 64)
+}

--- a/src/main/kotlin/com/example/demo/infrastructure/persistence/member/MemberExposedRepository.kt
+++ b/src/main/kotlin/com/example/demo/infrastructure/persistence/member/MemberExposedRepository.kt
@@ -1,0 +1,24 @@
+package com.example.demo.infrastructure.persistence.member
+
+import com.example.demo.core.member.domain.Member
+import com.example.demo.core.member.domain.Members
+import org.jetbrains.exposed.sql.batchInsert
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.springframework.stereotype.Repository
+
+@Repository
+class MemberExposedRepository {
+
+    // Jpa 엔티티를 사용하는 것이 마음에 들지 않지만, 우선은 Jpa 엔티티를 파라미터로 받아서 처리
+    fun saveAll(members: List<Member>) {
+        transaction {
+            Members.batchInsert(
+                data = members,
+                ignore = false,
+                shouldReturnGeneratedValues = false,
+            ) {
+                this[Members.name] = it.name
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/demo/CeilTest.kt
+++ b/src/test/kotlin/com/example/demo/CeilTest.kt
@@ -19,4 +19,4 @@ internal class CeilTest : FunSpec({
 
         actual shouldBe -4
     }
-})
+},)

--- a/src/test/kotlin/com/example/demo/FloorTest.kt
+++ b/src/test/kotlin/com/example/demo/FloorTest.kt
@@ -19,4 +19,4 @@ internal class FloorTest : FunSpec({
 
         actual shouldBe -5
     }
-})
+},)

--- a/src/test/kotlin/com/example/demo/RoundTest.kt
+++ b/src/test/kotlin/com/example/demo/RoundTest.kt
@@ -52,4 +52,4 @@ internal class RoundTest : FunSpec({
 
         actual shouldBe -5
     }
-})
+},)

--- a/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
+++ b/src/test/kotlin/com/example/demo/config/persistence/TransactionalTest.kt
@@ -1,9 +1,9 @@
 package com.example.demo.config.persistence
 
 import com.example.demo.core.order.domain.Order
-import com.example.demo.infrastructure.persistence.order.OrderRepository
 import com.example.demo.core.order.service.FindOrderService
 import com.example.demo.createOrder
+import com.example.demo.infrastructure.persistence.order.OrderRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
@@ -53,4 +53,4 @@ class TransactionalTest(
             }
         }
     }
-})
+},)

--- a/src/test/kotlin/com/example/demo/core/member/SaveMassMemberDataTest.kt
+++ b/src/test/kotlin/com/example/demo/core/member/SaveMassMemberDataTest.kt
@@ -7,18 +7,15 @@ import com.example.demo.infrastructure.persistence.member.MemberJdbcRepository
 import com.example.demo.infrastructure.persistence.member.MemberJpaRepository
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 
 @ActiveProfiles("test")
 @SpringBootTest
 @DisplayName("SaveMassMemberDataTest")
 class SaveMassMemberDataTest(
-    private val jdbcTemplate: JdbcTemplate,
     private val memberJpaRepository: MemberJpaRepository,
-    private val memberJdbcRepository: MemberJdbcRepository = MemberJdbcRepository(jdbcTemplate = jdbcTemplate),
+    private val memberJdbcRepository: MemberJdbcRepository,
     private val memberExposedRepository: MemberExposedRepository,
 ) : FunSpec({
 

--- a/src/test/kotlin/com/example/demo/core/member/SaveMassMemberDataTest.kt
+++ b/src/test/kotlin/com/example/demo/core/member/SaveMassMemberDataTest.kt
@@ -2,19 +2,24 @@ package com.example.demo.core.member
 
 import com.example.demo.core.member.domain.Member
 import com.example.demo.createMember
+import com.example.demo.infrastructure.persistence.member.MemberExposedRepository
 import com.example.demo.infrastructure.persistence.member.MemberJdbcRepository
 import com.example.demo.infrastructure.persistence.member.MemberJpaRepository
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.FunSpec
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.ActiveProfiles
 
-@DataJpaTest
+@ActiveProfiles("test")
+@SpringBootTest
 @DisplayName("SaveMassMemberDataTest")
 class SaveMassMemberDataTest(
     private val jdbcTemplate: JdbcTemplate,
     private val memberJpaRepository: MemberJpaRepository,
     private val memberJdbcRepository: MemberJdbcRepository = MemberJdbcRepository(jdbcTemplate = jdbcTemplate),
+    private val memberExposedRepository: MemberExposedRepository,
 ) : FunSpec({
 
     val count = 1_000
@@ -41,5 +46,14 @@ class SaveMassMemberDataTest(
         }
 
         memberJdbcRepository.saveAll(members)
+    }
+
+    test("1000명의 회원 데이터를 Exposed batchInsert()로 저장했을 때") {
+        val members: MutableList<Member> = mutableListOf()
+        for (i in 1 .. count) {
+            members.add(createMember())
+        }
+
+        memberExposedRepository.saveAll(members)
     }
 })

--- a/src/test/kotlin/com/example/demo/core/member/domain/MembersTest.kt
+++ b/src/test/kotlin/com/example/demo/core/member/domain/MembersTest.kt
@@ -1,0 +1,18 @@
+package com.example.demo.core.member.domain
+
+import io.kotest.core.annotation.DisplayName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlin.reflect.full.memberProperties
+
+@DisplayName("Members")
+internal class MembersTest : FunSpec({
+    test("Member Jpa와 Exposed의 엔티티 필드는 동일해야 한다.") {
+        val jpaProperties = Member::class.memberProperties.map { it.name }
+        val exposedProperties = Members::class.memberProperties.map { it.name }
+
+        jpaProperties.forEach { property ->
+            exposedProperties.any { it == property } shouldBe true
+        }
+    }
+},)

--- a/src/test/kotlin/com/example/demo/core/member/service/FindMemberCountServiceTest.kt
+++ b/src/test/kotlin/com/example/demo/core/member/service/FindMemberCountServiceTest.kt
@@ -1,9 +1,9 @@
 package com.example.demo.core.member.service
 
 import com.example.demo.core.member.domain.Member
-import com.example.demo.infrastructure.persistence.member.MemberRepository
 import com.example.demo.createMember
 import com.example.demo.infrastructure.persistence.member.MemberJpaRepository
+import com.example.demo.infrastructure.persistence.member.MemberRepository
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -38,4 +38,4 @@ class FindMemberCountServiceTest(
             }
         }
     }
-})
+},)

--- a/src/test/kotlin/com/example/demo/core/order/service/FindOrderServiceTest.kt
+++ b/src/test/kotlin/com/example/demo/core/order/service/FindOrderServiceTest.kt
@@ -1,8 +1,8 @@
 package com.example.demo.core.order.service
 
 import com.example.demo.core.order.domain.Order
-import com.example.demo.infrastructure.persistence.order.OrderRepository
 import com.example.demo.createOrder
+import com.example.demo.infrastructure.persistence.order.OrderRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.DisplayName
 import io.kotest.core.spec.style.DescribeSpec
@@ -41,4 +41,4 @@ class FindOrderServiceTest(
             }
         }
     }
-})
+},)

--- a/src/test/kotlin/com/example/demo/infrastructure/persistence/SaveMassMemberDataTest.kt
+++ b/src/test/kotlin/com/example/demo/infrastructure/persistence/SaveMassMemberDataTest.kt
@@ -47,10 +47,10 @@ class SaveMassMemberDataTest(
 
     test("1000명의 회원 데이터를 Exposed batchInsert()로 저장했을 때") {
         val members: MutableList<Member> = mutableListOf()
-        for (i in 1 .. count) {
+        for (i in 1..count) {
             members.add(createMember())
         }
 
         memberExposedRepository.saveAll(members)
     }
-})
+},)

--- a/src/test/kotlin/com/example/demo/infrastructure/persistence/SaveMassMemberDataTest.kt
+++ b/src/test/kotlin/com/example/demo/infrastructure/persistence/SaveMassMemberDataTest.kt
@@ -1,4 +1,4 @@
-package com.example.demo.core.member
+package com.example.demo.infrastructure.persistence
 
 import com.example.demo.core.member.domain.Member
 import com.example.demo.createMember

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,7 +32,10 @@ spring:
           batch_size: 1000
     open-in-view: false
 
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.type: trace
+logging.level:
+  org.hibernate.SQL: DEBUG
+  org.hibernate.type: TRACE
+  org.springframework.orm.jpa: DEBUG
+  org.springframework.transaction: DEBUG
+  org.springframework.jdbc: DEBUG
+  Exposed: DEBUG


### PR DESCRIPTION
코틀린 ORM Exposed 추가

Exposed 디펜던시 추가
1000건의 데이터 batch insert 테스트 코드 추가

jdbcTemplate > Exposed > Jpa saveAll > Jpa save 순으로 빠름

<img width="466" alt="스크린샷 2023-10-18 오후 4 29 39" src="https://github.com/junho3/practice-kotlin-spring-boot/assets/54342973/16a2ad6f-33d3-4a08-8ad5-f50576089874">

Jpa Member 엔티티를 파라미터로 받는게 마음에 들지 않지만, 도메인 모델까지 정의할 여유가 없으므로 우선 Jpa 엔티티를 받아서 batchInsert 하도록 함