### PR TITLE
Feature/add archunit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ dependencies {
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     testImplementation("com.h2database:h2")
     testImplementation("io.mockk:mockk:1.13.2")
-    testImplementation("com.tngtech.archunit:archunit:1.1.0")
+    testImplementation("com.tngtech.archunit:archunit-junit5:1.1.0")
 
     allOpen {
         annotation("javax.persistence.Entity")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.2")
     testImplementation("com.h2database:h2")
     testImplementation("io.mockk:mockk:1.13.2")
+    testImplementation("com.tngtech.archunit:archunit:1.1.0")
 
     allOpen {
         annotation("javax.persistence.Entity")

--- a/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
+++ b/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
@@ -10,8 +10,9 @@ import org.springframework.stereotype.Service
 class NamingConventionTest {
 
     @ArchTest
-    val servicesShouldBeSuffixed: ArchRule = ArchRuleDefinition.classes()
-        .that().resideInAPackage("..service..")
-        .and().areAnnotatedWith(Service::class.java)
-        .should().haveSimpleNameEndingWith("Service")
+    val servicesShouldBeSuffixed: ArchRule =
+        ArchRuleDefinition.classes()
+            .that().resideInAPackage("..service..")
+            .and().areAnnotatedWith(Service::class.java)
+            .should().haveSimpleNameEndingWith("Service")
 }

--- a/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
+++ b/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 class NamingConventionTest {
 
     @ArchTest
-    val services_should_be_suffixed: ArchRule = ArchRuleDefinition.classes()
+    val servicesShouldBeSuffixed: ArchRule = ArchRuleDefinition.classes()
         .that().resideInAPackage("..service..")
         .and().areAnnotatedWith(Service::class.java)
         .should().haveSimpleNameEndingWith("Service")

--- a/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
+++ b/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service
 
 @AnalyzeClasses(packages = ["com.example.demo"])
 class NamingConventionTest {
-
     @ArchTest
     val servicesShouldBeSuffixed: ArchRule =
         ArchRuleDefinition.classes()

--- a/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
+++ b/src/test/kotlin/com/example/demo/archunit/NamingConventionTest.kt
@@ -1,0 +1,17 @@
+package com.example.demo.archunit
+
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition
+import org.springframework.stereotype.Service
+
+@AnalyzeClasses(packages = ["com.example.demo"])
+class NamingConventionTest {
+
+    @ArchTest
+    val services_should_be_suffixed: ArchRule = ArchRuleDefinition.classes()
+        .that().resideInAPackage("..service..")
+        .and().areAnnotatedWith(Service::class.java)
+        .should().haveSimpleNameEndingWith("Service")
+}


### PR DESCRIPTION
ArchUnit 디펜던시를 추가하여 피트니스 함수 정의

클래스별 네이밍 규칙 검증
아직 컨트롤러가 존재하지 않아서 레이어드 아키텍처 검증은 제외하였음

https://github.com/TNG/ArchUnit

의존성 및 네이밍 규칙 검증에 실패하면 테스트 실패 발생
infrastructure.persistence 패키지에 있는 TestClass가 service 패키지의 CreateOrderService를 의존하여 테스트 실패

```
Constructor <com.example.demo.infrastructure.persistence.member.TestClass.<init>(com.example.demo.core.order.service.CreateOrderService)> has parameter of type <com.example.demo.core.order.service.CreateOrderService> in (TestClass.java:0)
Field <com.example.demo.infrastructure.persistence.member.TestClass.createOrderService> has type <com.example.demo.core.order.service.CreateOrderService> in (TestClass.java:0)
```