### PR TITLE
Feature/compare response status and response entity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.springframework.boot") version "3.3.0"
     id("io.spring.dependency-management") version "1.1.5"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
+    id("org.asciidoctor.jvm.convert") version "3.3.2"
     id("java-test-fixtures")
 
     kotlin("jvm") version "1.9.24"
@@ -20,6 +21,8 @@ version = "0.0.1-SNAPSHOT"
 java {
     sourceCompatibility = JavaVersion.VERSION_17
 }
+
+val asciidoctorExtensions: Configuration by configurations.creating
 
 repositories {
     mavenCentral()
@@ -57,6 +60,10 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.11")
     testImplementation("com.tngtech.archunit:archunit-junit5:1.1.0")
 
+    /** asciidoc */
+    asciidoctorExtensions("org.springframework.restdocs:spring-restdocs-asciidoctor")
+    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+
     testFixturesImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter-kotlin:1.0.16")
 
     allOpen {
@@ -81,4 +88,61 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+val snippetsDir by extra { file("$buildDir/generated-snippets") }
+val restdocsDir by extra { file("$buildDir/resources/main/static/docs") }
+
+tasks {
+
+    clean {
+        delete("src/main/resources/static/docs")
+    }
+
+    test {
+        // 위에서 작성한 snippetsDir 디렉토리를 test의 output으로 구성하는 설정 -> 스니펫 조각들이 build/generated-snippets로 출력
+        outputs.dir(snippetsDir)
+    }
+
+    build {
+        dependsOn("copyDocument")
+    }
+
+    // asciidoctor 작업 구성
+    asciidoctor {
+        dependsOn(test) // test 작업 이후에 작동하도록 하는 설정
+        configurations(asciidoctorExtensions.name) // 위에서 작성한 configuration 적용
+        inputs.dir(snippetsDir) // snippetsDir 를 입력으로 구성
+        attributes["project-version"] = project.version
+        attributes["source-highlighter"] = "prettify"
+
+        // source가 없으면 .adoc파일을 전부 html로 만들어버림
+        // source 지정시 특정 adoc만 HTML로 만든다.
+        sources {
+            include("**/index.adoc", "**/common/*.adoc")
+        }
+
+        // 특정 .adoc에 다른 adoc 파일을 가져와서(include) 사용하고 싶을 경우 경로를 baseDir로 맞춰주는 설정입니다.
+        // 개별 adoc 으로 운영한다면 필요 없는 옵션입니다.
+        baseDirFollowsSourceFile()
+
+        // static/docs 폴더 비우기
+        doFirst {
+            delete("src/main/resources/static/docs")
+        }
+    }
+
+    // asccidoctor 작업 이후 생성된 HTML 파일을 static/docs 로 copy
+    register<Copy>("copyDocument") {
+        dependsOn("asciidoctor")
+        from("build/docs/asciidoc")
+        into("src/main/resources/static/docs")
+    }
+
+    bootJar {
+        dependsOn(asciidoctor)
+        from("${asciidoctor.get().outputDir}") {
+            into("static/docs")
+        }
+    }
 }

--- a/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
+++ b/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
@@ -11,19 +11,19 @@ import org.springframework.web.bind.annotation.RestController
 class CreateOrderController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/v1/orders/response-status")
-    fun responseStatus(): ApiResponse<FindOrderResponse> {
-        return ApiResponse.success(
+    fun responseStatus(): ApiResponse<FindOrderResponse> =
+        ApiResponse.success(
             FindOrderResponse(
                 id = 1,
                 memberName = "xxx",
                 products = listOf(FindOrderResponse.Product(id = 1, name = "xxx", quantity = 1)),
             ),
         )
-    }
+
 
     @PostMapping("/v1/orders/response-entity")
-    fun responseEntity(): ResponseEntity<ApiResponse<FindOrderResponse>> {
-        return ResponseEntity
+    fun responseEntity(): ResponseEntity<ApiResponse<FindOrderResponse>> =
+        ResponseEntity
             .status(HttpStatus.CREATED)
             .body(
                 ApiResponse.success(
@@ -34,5 +34,4 @@ class CreateOrderController {
                     ),
                 ),
             )
-    }
 }

--- a/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
+++ b/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 class CreateOrderController {
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/v1/orders/response-entity")
+    @PostMapping("/v1/orders/response-status")
     fun responseStatus(): ApiResponse<FindOrderResponse> {
         return ApiResponse.success(FindOrderResponse(id = 1, memberName = "xxx", products = listOf()))
     }

--- a/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
+++ b/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
@@ -13,12 +13,26 @@ class CreateOrderController {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/v1/orders/response-status")
     fun responseStatus(): ApiResponse<FindOrderResponse> {
-        return ApiResponse.success(FindOrderResponse(id = 1, memberName = "xxx", products = listOf()))
+        return ApiResponse.success(
+            FindOrderResponse(
+                id = 1,
+                memberName = "xxx",
+                products = listOf(FindOrderResponse.Product(id = 1, name = "xxx", quantity = 1)),
+            ),
+        )
     }
 
     @PostMapping("/v1/orders/response-entity")
     fun responseEntity(): ResponseEntity<ApiResponse<FindOrderResponse>> {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ApiResponse.success(FindOrderResponse(id = 1, memberName = "xxx", products = listOf())))
+            .body(
+                ApiResponse.success(
+                    FindOrderResponse(
+                        id = 1,
+                        memberName = "xxx",
+                        products = listOf(FindOrderResponse.Product(id = 1, name = "xxx", quantity = 1)),
+                    ),
+                ),
+            )
     }
 }

--- a/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
+++ b/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
@@ -24,7 +24,8 @@ class CreateOrderController {
 
     @PostMapping("/v1/orders/response-entity")
     fun responseEntity(): ResponseEntity<ApiResponse<FindOrderResponse>> {
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
             .body(
                 ApiResponse.success(
                     FindOrderResponse(

--- a/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
+++ b/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class CreateOrderController {
-
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/v1/orders/response-status")
     fun responseStatus(): ApiResponse<FindOrderResponse> {

--- a/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
+++ b/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
@@ -1,0 +1,24 @@
+package com.example.demo.web.v1.order
+
+import com.example.demo.web.v1.ApiResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CreateOrderController {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/v1/orders/response-entity")
+    fun responseStatus(): ApiResponse<FindOrderResponse> {
+        return ApiResponse.success(FindOrderResponse(id = 1, memberName = "xxx", products = listOf()))
+    }
+
+    @PostMapping("/v1/orders/response-entity")
+    fun responseEntity(): ResponseEntity<ApiResponse<FindOrderResponse>> {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(FindOrderResponse(id = 1, memberName = "xxx", products = listOf())))
+    }
+}

--- a/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
+++ b/src/main/kotlin/com/example/demo/web/v1/order/CreateOrderController.kt
@@ -20,7 +20,6 @@ class CreateOrderController {
             ),
         )
 
-
     @PostMapping("/v1/orders/response-entity")
     fun responseEntity(): ResponseEntity<ApiResponse<FindOrderResponse>> =
         ResponseEntity

--- a/src/test/kotlin/com/example/demo/AnnotationFixtures.kt
+++ b/src/test/kotlin/com/example/demo/AnnotationFixtures.kt
@@ -1,6 +1,7 @@
 package com.example.demo
 
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
@@ -15,8 +16,10 @@ annotation class TestEnvironment
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-@TestEnvironment
+@AutoConfigureRestDocs
 @AutoConfigureMockMvc
+@SpringBootTest
+@TestEnvironment
 annotation class RestDocsTest
 
 @Import(value = [QuerydslTestConfig::class])

--- a/src/test/kotlin/com/example/demo/RestdocsUtils.kt
+++ b/src/test/kotlin/com/example/demo/RestdocsUtils.kt
@@ -8,21 +8,19 @@ import org.springframework.restdocs.payload.JsonFieldType.STRING
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 
 object RestdocsUtils {
-    fun objectResponse(): Array<FieldDescriptor> {
-        return arrayOf(
+    fun objectResponse(): Array<FieldDescriptor> =
+        arrayOf(
             fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
             fieldWithPath("code").type(STRING).description("실패 시 에러 코드").optional(),
             fieldWithPath("message").type(STRING).description("실패 시 메시지").optional(),
             fieldWithPath("data").type(OBJECT).description("응답 데이터").optional(),
         )
-    }
 
-    fun arrayResponse(): Array<FieldDescriptor> {
-        return arrayOf(
+    fun arrayResponse(): Array<FieldDescriptor> =
+        arrayOf(
             fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
             fieldWithPath("code").type(STRING).description("실패 시 에러 코드").optional(),
             fieldWithPath("message").type(STRING).description("실패 시 메시지").optional(),
             fieldWithPath("data").type(ARRAY).description("응답 데이터").optional(),
         )
-    }
 }

--- a/src/test/kotlin/com/example/demo/RestdocsUtils.kt
+++ b/src/test/kotlin/com/example/demo/RestdocsUtils.kt
@@ -1,0 +1,28 @@
+package com.example.demo
+
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.JsonFieldType.ARRAY
+import org.springframework.restdocs.payload.JsonFieldType.BOOLEAN
+import org.springframework.restdocs.payload.JsonFieldType.OBJECT
+import org.springframework.restdocs.payload.JsonFieldType.STRING
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+
+object RestdocsUtils {
+    fun objectResponse(): Array<FieldDescriptor> {
+        return arrayOf(
+            fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+            fieldWithPath("code").type(STRING).description("실패 시 에러 코드").optional(),
+            fieldWithPath("message").type(STRING).description("실패 시 메시지").optional(),
+            fieldWithPath("data").type(OBJECT).description("응답 데이터").optional(),
+        )
+    }
+
+    fun arrayResponse(): Array<FieldDescriptor> {
+        return arrayOf(
+            fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+            fieldWithPath("code").type(STRING).description("실패 시 에러 코드").optional(),
+            fieldWithPath("message").type(STRING).description("실패 시 메시지").optional(),
+            fieldWithPath("data").type(ARRAY).description("응답 데이터").optional(),
+        )
+    }
+}

--- a/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
@@ -58,8 +58,7 @@ internal class CreateOrderControllerTest(
                                                 .description("상품 수량"),
                                         ),
                                 ),
-                            )
-                            .andReturn()
+                            ).andReturn()
                     }
                 }
             }
@@ -102,8 +101,7 @@ internal class CreateOrderControllerTest(
                                                 .description("상품 수량"),
                                         ),
                                 ),
-                            )
-                            .andReturn()
+                            ).andReturn()
                     }
                 }
             }

--- a/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
@@ -17,79 +17,79 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 internal class CreateOrderControllerTest(
     private val mockMvc: MockMvc,
 ) : DescribeSpec(
-    {
-        extensions(SpringExtension)
+        {
+            extensions(SpringExtension)
 
-        describe("responseStatus()") {
+            describe("responseStatus()") {
 
-            context("올바른 요청이 들어오면") {
+                context("올바른 요청이 들어오면") {
 
-                it("201 응답을 리턴한다.") {
-                    mockMvc.perform(
-                        RestDocumentationRequestBuilders.post("/v1/orders/response-status")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .accept(MediaType.APPLICATION_JSON),
-                    )
-                        .andExpect(MockMvcResultMatchers.status().isCreated)
-                        .andDo(
-                            MockMvcRestDocumentation.document(
-                                "post/v1/orders/response-status",
-                                PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
-                                    .and(
-                                        PayloadDocumentation.fieldWithPath("data.id")
-                                            .description("주문 id"),
-                                        PayloadDocumentation.fieldWithPath("data.memberName")
-                                            .description("회원명"),
-                                        PayloadDocumentation.fieldWithPath("data.products[]")
-                                            .description("상품 목록"),
-                                        PayloadDocumentation.fieldWithPath("data.products[].id")
-                                            .description("상품 id"),
-                                        PayloadDocumentation.fieldWithPath("data.products[].name")
-                                            .description("상품 이름"),
-                                        PayloadDocumentation.fieldWithPath("data.products[].quantity")
-                                            .description("상품 수량"),
-                                    ),
-                            ),
+                    it("201 응답을 리턴한다.") {
+                        mockMvc.perform(
+                            RestDocumentationRequestBuilders.post("/v1/orders/response-status")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON),
                         )
-                        .andReturn()
+                            .andExpect(MockMvcResultMatchers.status().isCreated)
+                            .andDo(
+                                MockMvcRestDocumentation.document(
+                                    "post/v1/orders/response-status",
+                                    PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
+                                        .and(
+                                            PayloadDocumentation.fieldWithPath("data.id")
+                                                .description("주문 id"),
+                                            PayloadDocumentation.fieldWithPath("data.memberName")
+                                                .description("회원명"),
+                                            PayloadDocumentation.fieldWithPath("data.products[]")
+                                                .description("상품 목록"),
+                                            PayloadDocumentation.fieldWithPath("data.products[].id")
+                                                .description("상품 id"),
+                                            PayloadDocumentation.fieldWithPath("data.products[].name")
+                                                .description("상품 이름"),
+                                            PayloadDocumentation.fieldWithPath("data.products[].quantity")
+                                                .description("상품 수량"),
+                                        ),
+                                ),
+                            )
+                            .andReturn()
+                    }
                 }
             }
-        }
 
-        describe("responseEntity()는") {
+            describe("responseEntity()는") {
 
-            context("올바른 요청이 들어오면") {
+                context("올바른 요청이 들어오면") {
 
-                it("201 응답을 리턴한다.") {
-                    mockMvc.perform(
-                        RestDocumentationRequestBuilders.post("/v1/orders/response-entity")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .accept(MediaType.APPLICATION_JSON),
-                    )
-                        .andExpect(MockMvcResultMatchers.status().isCreated)
-                        .andDo(
-                            MockMvcRestDocumentation.document(
-                                "post/v1/orders/response-entity",
-                                PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
-                                    .and(
-                                        PayloadDocumentation.fieldWithPath("data.id")
-                                            .description("주문 id"),
-                                        PayloadDocumentation.fieldWithPath("data.memberName")
-                                            .description("회원명"),
-                                        PayloadDocumentation.fieldWithPath("data.products[]")
-                                            .description("상품 목록"),
-                                        PayloadDocumentation.fieldWithPath("data.products[].id")
-                                            .description("상품 id"),
-                                        PayloadDocumentation.fieldWithPath("data.products[].name")
-                                            .description("상품 이름"),
-                                        PayloadDocumentation.fieldWithPath("data.products[].quantity")
-                                            .description("상품 수량"),
-                                    ),
-                            ),
+                    it("201 응답을 리턴한다.") {
+                        mockMvc.perform(
+                            RestDocumentationRequestBuilders.post("/v1/orders/response-entity")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON),
                         )
-                        .andReturn()
+                            .andExpect(MockMvcResultMatchers.status().isCreated)
+                            .andDo(
+                                MockMvcRestDocumentation.document(
+                                    "post/v1/orders/response-entity",
+                                    PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
+                                        .and(
+                                            PayloadDocumentation.fieldWithPath("data.id")
+                                                .description("주문 id"),
+                                            PayloadDocumentation.fieldWithPath("data.memberName")
+                                                .description("회원명"),
+                                            PayloadDocumentation.fieldWithPath("data.products[]")
+                                                .description("상품 목록"),
+                                            PayloadDocumentation.fieldWithPath("data.products[].id")
+                                                .description("상품 id"),
+                                            PayloadDocumentation.fieldWithPath("data.products[].name")
+                                                .description("상품 이름"),
+                                            PayloadDocumentation.fieldWithPath("data.products[].quantity")
+                                                .description("상품 수량"),
+                                        ),
+                                ),
+                            )
+                            .andReturn()
+                    }
                 }
             }
-        }
-    },
-)
+        },
+    )

--- a/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
@@ -27,7 +27,8 @@ internal class CreateOrderControllerTest(
                     it("201 응답을 리턴한다.") {
                         mockMvc
                             .perform(
-                                RestDocumentationRequestBuilders.post("/v1/orders/response-status")
+                                RestDocumentationRequestBuilders
+                                    .post("/v1/orders/response-status")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .accept(MediaType.APPLICATION_JSON),
                             ).andExpect(MockMvcResultMatchers.status().isCreated)
@@ -70,7 +71,8 @@ internal class CreateOrderControllerTest(
                     it("201 응답을 리턴한다.") {
                         mockMvc
                             .perform(
-                                RestDocumentationRequestBuilders.post("/v1/orders/response-entity")
+                                RestDocumentationRequestBuilders
+                                    .post("/v1/orders/response-entity")
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .accept(MediaType.APPLICATION_JSON),
                             ).andExpect(MockMvcResultMatchers.status().isCreated)

--- a/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
@@ -1,0 +1,95 @@
+package com.example.demo.web.v1.order
+
+import com.example.demo.RestDocsTest
+import com.example.demo.RestdocsUtils
+import io.kotest.core.spec.DisplayName
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@RestDocsTest
+@DisplayName("CreateOrderController")
+internal class CreateOrderControllerTest(
+    private val mockMvc: MockMvc,
+) : DescribeSpec(
+    {
+        extensions(SpringExtension)
+
+        describe("responseStatus()") {
+
+            context("올바른 요청이 들어오면") {
+
+                it("201 응답을 리턴한다.") {
+                    mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/v1/orders/response-status")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON),
+                    )
+                        .andExpect(MockMvcResultMatchers.status().isCreated)
+                        .andDo(
+                            MockMvcRestDocumentation.document(
+                                "post/v1/orders/response-status",
+                                PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
+                                    .and(
+                                        PayloadDocumentation.fieldWithPath("data.id")
+                                            .description("주문 id"),
+                                        PayloadDocumentation.fieldWithPath("data.memberName")
+                                            .description("회원명"),
+                                        PayloadDocumentation.fieldWithPath("data.products[]")
+                                            .description("상품 목록"),
+                                        PayloadDocumentation.fieldWithPath("data.products[].id")
+                                            .description("상품 id"),
+                                        PayloadDocumentation.fieldWithPath("data.products[].name")
+                                            .description("상품 이름"),
+                                        PayloadDocumentation.fieldWithPath("data.products[].quantity")
+                                            .description("상품 수량"),
+                                    ),
+                            ),
+                        )
+                        .andReturn()
+                }
+            }
+        }
+
+        describe("responseEntity()는") {
+
+            context("올바른 요청이 들어오면") {
+
+                it("201 응답을 리턴한다.") {
+                    mockMvc.perform(
+                        RestDocumentationRequestBuilders.post("/v1/orders/response-entity")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaType.APPLICATION_JSON),
+                    )
+                        .andExpect(MockMvcResultMatchers.status().isCreated)
+                        .andDo(
+                            MockMvcRestDocumentation.document(
+                                "post/v1/orders/response-entity",
+                                PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
+                                    .and(
+                                        PayloadDocumentation.fieldWithPath("data.id")
+                                            .description("주문 id"),
+                                        PayloadDocumentation.fieldWithPath("data.memberName")
+                                            .description("회원명"),
+                                        PayloadDocumentation.fieldWithPath("data.products[]")
+                                            .description("상품 목록"),
+                                        PayloadDocumentation.fieldWithPath("data.products[].id")
+                                            .description("상품 id"),
+                                        PayloadDocumentation.fieldWithPath("data.products[].name")
+                                            .description("상품 이름"),
+                                        PayloadDocumentation.fieldWithPath("data.products[].quantity")
+                                            .description("상품 수량"),
+                                    ),
+                            ),
+                        )
+                        .andReturn()
+                }
+            }
+        }
+    },
+)

--- a/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/web/v1/order/CreateOrderControllerTest.kt
@@ -25,28 +25,35 @@ internal class CreateOrderControllerTest(
                 context("올바른 요청이 들어오면") {
 
                     it("201 응답을 리턴한다.") {
-                        mockMvc.perform(
-                            RestDocumentationRequestBuilders.post("/v1/orders/response-status")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON),
-                        )
-                            .andExpect(MockMvcResultMatchers.status().isCreated)
+                        mockMvc
+                            .perform(
+                                RestDocumentationRequestBuilders.post("/v1/orders/response-status")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON),
+                            ).andExpect(MockMvcResultMatchers.status().isCreated)
                             .andDo(
                                 MockMvcRestDocumentation.document(
                                     "post/v1/orders/response-status",
-                                    PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
+                                    PayloadDocumentation
+                                        .responseFields(*RestdocsUtils.objectResponse())
                                         .and(
-                                            PayloadDocumentation.fieldWithPath("data.id")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.id")
                                                 .description("주문 id"),
-                                            PayloadDocumentation.fieldWithPath("data.memberName")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.memberName")
                                                 .description("회원명"),
-                                            PayloadDocumentation.fieldWithPath("data.products[]")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[]")
                                                 .description("상품 목록"),
-                                            PayloadDocumentation.fieldWithPath("data.products[].id")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[].id")
                                                 .description("상품 id"),
-                                            PayloadDocumentation.fieldWithPath("data.products[].name")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[].name")
                                                 .description("상품 이름"),
-                                            PayloadDocumentation.fieldWithPath("data.products[].quantity")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[].quantity")
                                                 .description("상품 수량"),
                                         ),
                                 ),
@@ -61,28 +68,35 @@ internal class CreateOrderControllerTest(
                 context("올바른 요청이 들어오면") {
 
                     it("201 응답을 리턴한다.") {
-                        mockMvc.perform(
-                            RestDocumentationRequestBuilders.post("/v1/orders/response-entity")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON),
-                        )
-                            .andExpect(MockMvcResultMatchers.status().isCreated)
+                        mockMvc
+                            .perform(
+                                RestDocumentationRequestBuilders.post("/v1/orders/response-entity")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .accept(MediaType.APPLICATION_JSON),
+                            ).andExpect(MockMvcResultMatchers.status().isCreated)
                             .andDo(
                                 MockMvcRestDocumentation.document(
                                     "post/v1/orders/response-entity",
-                                    PayloadDocumentation.responseFields(*RestdocsUtils.objectResponse())
+                                    PayloadDocumentation
+                                        .responseFields(*RestdocsUtils.objectResponse())
                                         .and(
-                                            PayloadDocumentation.fieldWithPath("data.id")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.id")
                                                 .description("주문 id"),
-                                            PayloadDocumentation.fieldWithPath("data.memberName")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.memberName")
                                                 .description("회원명"),
-                                            PayloadDocumentation.fieldWithPath("data.products[]")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[]")
                                                 .description("상품 목록"),
-                                            PayloadDocumentation.fieldWithPath("data.products[].id")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[].id")
                                                 .description("상품 id"),
-                                            PayloadDocumentation.fieldWithPath("data.products[].name")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[].name")
                                                 .description("상품 이름"),
-                                            PayloadDocumentation.fieldWithPath("data.products[].quantity")
+                                            PayloadDocumentation
+                                                .fieldWithPath("data.products[].quantity")
                                                 .description("상품 수량"),
                                         ),
                                 ),


### PR DESCRIPTION
ResponseEntity 적용 및 비교

201로 리턴하는 케이스
```
As-is
@ResponseStatus(HttpStatus.CREATED)
ApiResponse.success(data)

HTTP/1.1 201 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Tue, 04 Jun 2024 23:29:55 GMT

To-be
ResponseEntity.status(HttpStatus.CREATED)
    .body(ApiResponse.success(data))

HTTP/1.1 201 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Tue, 04 Jun 2024 23:30:55 GMT
```

컨트롤러 테스트 코드가 통과하는 것으로봐서 `@ResponseStatus(HttpStatus.CREATED)`를 제거하고, `ResponseEntity`로 변경했을 때 응답 구조가 바뀌는건 아닌 것 같음

헤더에 추가적인 작업이 필요한 것이 아닌 이상 201 응답은 어노테이션 방식이 더 편한 것 같음
불필요하게 ResponseEntity를 한번 더 감싸는 느낌

200으로 리턴하는 케이스
`ResponseEntity.ok(ApiResponse.success(data))`만 선언해도 되서 201에 비해 사용상 불편한 점은 없었음